### PR TITLE
fix(newrelic): stringify application error details before sending to newrelic

### DIFF
--- a/plugins/grpc/interceptors/newrelic.go
+++ b/plugins/grpc/interceptors/newrelic.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -84,7 +85,7 @@ func (i NewrelicInterceptor) Handler() grpc.UnaryServerInterceptor {
 				if !ae.Expected() {
 					nrErr, _ := nrpkgerrors.Wrap(err).(newrelic.Error)
 					nrErr.Attributes["trace_id"] = ae.TraceID()
-					nrErr.Attributes["details"] = ae.Details()
+					nrErr.Attributes["details"] = fmt.Sprintf("%v", ae.Details()) // newrelic doesn't allow sending []interface{} in attributes
 					txn.NoticeError(nrErr)
 				}
 			} else {

--- a/plugins/grpc/interceptors/newrelic.go
+++ b/plugins/grpc/interceptors/newrelic.go
@@ -85,7 +85,7 @@ func (i NewrelicInterceptor) Handler() grpc.UnaryServerInterceptor {
 				if !ae.Expected() {
 					nrErr, _ := nrpkgerrors.Wrap(err).(newrelic.Error)
 					nrErr.Attributes["trace_id"] = ae.TraceID()
-					nrErr.Attributes["details"] = fmt.Sprintf("%v", ae.Details()) // newrelic doesn't allow sending []interface{} in attributes
+					nrErr.Attributes["details"] = fmt.Sprintf("%#v", ae.Details()) // newrelic doesn't allow sending []interface{} in attributes
 					txn.NoticeError(nrErr)
 				}
 			} else {


### PR DESCRIPTION
Seeing
`level=error msg=\"unable to notice error\" component=newrelic reason=\"attribute 'details' value of type []interface {} is invalid\"\n"`