### PR TITLE
[SL-38176] feat: make server options configurable

### DIFF
--- a/plugins/grpc/grpc.go
+++ b/plugins/grpc/grpc.go
@@ -27,6 +27,12 @@ type GrpcServer struct {
 	listener *net.Listener
 }
 
+var globalServerOptions []grpc.ServerOption
+
+func SetGlobalServerOptions(options ...grpc.ServerOption) {
+	globalServerOptions = options
+}
+
 func (g GrpcServer) Server() *grpc.Server {
 	return g.server
 }
@@ -63,6 +69,7 @@ func (g *GrpcServer) Shutdown() {
 }
 
 func (g *GrpcServer) Configure(opt ...grpc.ServerOption) {
+	opt = append(globalServerOptions, opt...)
 	grpc := grpc.NewServer(opt...)
 	reflection.Register(grpc)
 	g.server = grpc


### PR DESCRIPTION
## Why?
預設 grpc 接收的 request payload 上限為 4mb，
但因為 blog-service 文章數較多時，有可能會超過，
需要拉高上限時發現沒有地方可以調整。

## How?
新增一個方式可以調整 server 設定

## Test Plan
ENG self-testing / QA testing

## Others
### Usage 
```go
func (m *GrpcModule) Provide() []interface{} {
	goAppGrpc.SetGlobalServerOptions(grpc.MaxRecvMsgSize(20 * 1024 * 1024))

	return []interface{}{
		func(
			grpcServer *presets.DefaultGrpcServerWithNewrelic,
			postsController *controllers.PostsController,
		) *GrpcModule {
```