### PR TITLE
fix: skip pyroscope start when ENABLE_PYROSCOPE is not true

### DIFF
--- a/plugins/pyroscope/pyroscope.go
+++ b/plugins/pyroscope/pyroscope.go
@@ -6,6 +6,7 @@ package pyroscope
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
 
 	"github.com/grafana/pyroscope-go"
@@ -61,8 +62,11 @@ func (p *PyroscopeAgent) Configure(configs ...PyroscopeAgentConfigOption) error 
 }
 
 func (p *PyroscopeAgent) Start() error {
+	if os.Getenv("ENABLE_PYROSCOPE") != "true" {
+		return nil
+	}
 	if p.config == nil {
-		return ErrAgentConfig
+		return nil
 	}
 
 	profile, err := pyroscope.Start(*p.config)


### PR DESCRIPTION
# Why?

When pyroscope build tag is enabled but ENABLE_PYROSCOPE env var is not set (e.g. in test environments), the fx lifecycle OnStart hook calls Start() which returns an error because config is nil. This causes the entire application to crash during tests.

# How?

- Check ENABLE_PYROSCOPE env var in Start() — if not "true", silently return nil
- If config is nil (Configure() was never called), also return nil instead of returning an error

This makes the plugin safe to include via build tags without requiring env vars in every environment.